### PR TITLE
celsius-friendly setPoint range

### DIFF
--- a/scripts/bodies.js
+++ b/scripts/bodies.js
@@ -116,7 +116,7 @@
                     var divPopover = $('<div></div>');
                     divPopover.appendTo(el.parent());
                     divPopover.on('initPopover', function (evt) {
-                        $('<div></div>').appendTo(evt.contents()).valueSpinner({ canEdit: true, labelText: 'Set Point', val: settings.setPoint, min: 65, max: 104, step: 1, bind:'heatSetpoint', units: '<span>&deg;</span><span class="picTempUnits">' + units + '</span>', labelAttrs: { style: { marginRight: '.25rem' } } });
+                        $('<div></div>').appendTo(evt.contents()).valueSpinner({ canEdit: true, labelText: 'Set Point', val: settings.setPoint, min: units === "F" ? 65 : 5, max: units === "F" ? 104 : 41, step: 1, bind:'heatSetpoint', units: '<span>&deg;</span><span class="picTempUnits">' + units + '</span>', labelAttrs: { style: { marginRight: '.25rem' } } });
                         $('<div></div>').appendTo(evt.contents()).selector({ val: parseInt(body.attr('data-heatmode'), 10), test: 'text', opts: data, bind: 'heatMode' });
                         //console.log(settings);
                         //$('<div><label class="picInline-label picSetpointText">' + body.attr('data-body') + ' Set Point</label><div class="picValueSpinner" data-bind="heatSetpoint"></div></div>'


### PR DESCRIPTION
currently the heater popover enforces a 65 degree minimum set point which is out-of-range for celsius.

min/max should probably come from server settings, but for now this quick fix will allow for a useable set point.

closes https://github.com/rstrouse/nodejs-poolController-dashPanel/issues/25