### PR TITLE
add git to final stage of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 RUN npm ci --production
 
 FROM node:lts-alpine
+RUN apk add git
 RUN mkdir /app && chown node:node /app && mkdir /app/data && chown node:node /app/data
 WORKDIR /app
 COPY --chown=node:node --from=build /app .


### PR DESCRIPTION
avoids git errors e.g. 

```
/bin/sh: git: not found
```

during runtime