### PR TITLE
Enable https: server for dashPanel

### DIFF
--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -11,7 +11,7 @@
         "authFile": "/users.htpasswd"
       },
       "https": {
-        "enabled": true,
+        "enabled": false,
         "ip": "0.0.0.0",
         "port": 5151,
         "authentication": "none",

--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -12,12 +12,12 @@
       },
       "https": {
         "enabled": true,
-        "ip": "127.0.0.1",
+        "ip": "0.0.0.0",
         "port": 5151,
         "authentication": "none",
         "authFile": "/users.htpasswd",
-        "sslKeyFile": "",
-        "sslCertFile": ""
+        "sslKeyFile": "/ssl/privkey.pem",
+        "sslCertFile": "/ssl/cert.pem"
       },
       "mdns": { "enabled": false },
       "sspd": { "enabled": false },

--- a/server/Server.ts
+++ b/server/Server.ts
@@ -36,7 +36,7 @@ export class WebServer {
                     srv.init(c);
                     break;
                 case 'https':
-                    srv = new Http2Server();
+                    srv = new HttpsServer();
                     this._servers.push(srv);
                     srv.init(cfg.servers[s]);
                     break;


### PR DESCRIPTION
https code in Server.ts was largely reused from nodej-poolController. As written this server.ts file removes the 'srv = new Http2Server' statement, as Http2 is not a complete function at this time.

Note the main config.json file will default to https disabled, requiring the user to explicitly enable it while verifying location of private key and cert. 