### PR TITLE
Schedules config visual

### DIFF
--- a/scripts/bodies.js
+++ b/scripts/bodies.js
@@ -37,8 +37,8 @@
         setTemps: function (data) {
             var self = this, o = self.options, el = self.element;
             var nSolar = 0;
-            if (typeof data.air !== 'undefined') el.find('span.picAirTemp').text(data.air.format('#,##0.##', '--'));
-            if (typeof data.solar !== 'undefined') el.find('span.picSolarTemp').text(data.solar.format('#,##0.##', '--'));
+            if (typeof data.air !== 'undefined') el.find('span.picAirTemp').text(data.air.format('#,##0.#', '--'));
+            if (typeof data.solar !== 'undefined') el.find('span.picSolarTemp').text(data.solar.format('#,##0.#', '--'));
             if (typeof data.units !== 'undefined') {
                 el.find('span.picTempUnits').text(data.units.name);
                 el.attr('data-unitsname', data.units.name);

--- a/scripts/config/schedules.js
+++ b/scripts/config/schedules.js
@@ -61,7 +61,7 @@
             });
             var pnl = acc.find('div.picAccordian-contents');
             // Figure out our formats.
-            o.fmtTime = o.clockMode === 12 ? 'h:mmtt' : 'H:mm';
+            o.fmtTime = o.clockMode === 12 ? 'h:mmtt' : 'HH:mm';
             o.fmtTimeEmpty = o.clockMode === 12 ? '12:00am' : '24:00';
 
             var line = $('<div></div>').addClass('schedule-circuit').appendTo(pnl);


### PR DESCRIPTION
On the schedules config page, when 24 hour time format is selected, the time is displayed as H:mm. This pull request is to change that display to a (more standard?) more visually appealing HH:mm.