### PR TITLE
Added support for Century Regal modbus pumps

### DIFF
--- a/scripts/messages/messageList.js
+++ b/scripts/messages/messageList.js
@@ -2069,7 +2069,8 @@ mhelper.init();
                     { val: 'chlorinator', desc: 'Chlorinator' },
                     { val: 'pump', desc: 'Pump' },
                     { val: 'intellivalve', desc: 'Intellivalve' },
-                    { val: 'intellichem', desc: 'Intellichem' }],
+                    { val: 'intellichem', desc: 'Intellichem' },
+                    { val: 'regalmodbus', desc: 'Regal Modbus' }],
                 inputAttrs: { style: { width: '7rem' } }, labelAttrs: { style: { width: '4rem' } }
             });
             proto.on('selchanged', function (evt) {

--- a/scripts/pumps.js
+++ b/scripts/pumps.js
@@ -130,6 +130,7 @@
                     case 'hwvs':
                     case 'vs':
                     case 'vs+svrs':
+                    case 'regalmodbus':
                         el.find('div.picProgram').hide();
                         el.find('div.picFlow').hide();
                         el.find('div.picSpeed').show();

--- a/server/messages/docs/constants.json
+++ b/server/messages/docs/constants.json
@@ -823,6 +823,17 @@
       "source": false,
       "controller": false,
       "keyFormat": "SL_<dest>_<action>"
+    },
+    {
+      "name": "regalmodbus",
+      "desc": "Regal Modbus",
+      "actions": {
+        "all": []
+      },
+      "source": false,
+      "controller": false,
+      "length": false,
+      "keyFormat": "<address>_<function>_<ack>_<data>_<crclo>_<crchi>"
     }
   ],
   "controllers": [


### PR DESCRIPTION
Minor refactoring to support [njsPC pull request 1120](https://github.com/tagyoureit/nodejs-poolController/pull/1120), which adds support for configuring and displaying information (rpms/power) for Century (Regal) modbus pumps.

Adds a hex representation for pump addresses if using njsPC with the above referenced changes.

These changes should maintain backward compatibility with earlier njsPC versions.