### PR TITLE
Ignore BOM when reading config

### DIFF
--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "web": {
     "servers": {
       "http2": { "enabled": false },

--- a/server/config/Config.ts
+++ b/server/config/Config.ts
@@ -10,9 +10,9 @@ class Config {
         this.cfgPath = path.posix.join(process.cwd(), "/config.json");
         // RKS 05-18-20: This originally had multiple points of failure where it was not in the try/catch.
         try {
-            this._cfg = fs.existsSync(this.cfgPath) ? JSON.parse(fs.readFileSync(this.cfgPath, "utf8")) : {};
-            const def = JSON.parse(fs.readFileSync(path.join(process.cwd(), "/defaultConfig.json"), "utf8").trim());
-            const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), "/package.json"), "utf8").trim());
+            this._cfg = fs.existsSync(this.cfgPath) ? JSON.parse(fs.readFileSync(this.cfgPath, "utf8").replace(/^\uFEFF/, '')) : {};
+            const def = JSON.parse(fs.readFileSync(path.join(process.cwd(), "/defaultConfig.json"), "utf8").replace(/^\uFEFF/, '').trim());
+            const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), "/package.json"), "utf8").replace(/^\uFEFF/, '').trim());
             this._cfg = extend(true, {}, def, this._cfg, { appVersion: { installed: packageJson.version } });
             this._isInitialized = true;
             this.getEnvVariables();


### PR DESCRIPTION
As config files might be manipulated by humans, some editors might introduce [UTF-8 BOM marker](https://en.wikipedia.org/wiki/Byte_order_mark).
This fix just removes them from the read configurations as `JSON.parse()` will not accept them and `readFileSync()` does not clear them, nor should it.
Here's what the error looks like:

```
Error reading configuration information.  Aborting startup: SyntaxError: Unexpected token '﻿', "﻿{
  "web""... is not valid JSON
/app/dist/server/config/Config.js:27
            throw err;
            ^

SyntaxError: Unexpected token '﻿', "﻿{
  "web""... is not valid JSON
    at JSON.parse (<anonymous>)
    at new Config (/app/dist/server/config/Config.js:16:60)
    at Object.<anonymous> (/app/dist/server/config/Config.js:106:18)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/app/dist/server/logger/Logger.js:5:18)
```

Also, the defaultConfig.json currently seems to have a BOM:
```
> hexdump -C defaultConfig.json
00000000  ef bb bf 7b 0a 20 20 22  77 65 62 22 3a 20 7b 0a  |...{.  "web": {.|
00000010  20 20 20 20 22 73 65 72  76 65 72 73 22 3a 20 7b  |    "servers": {|
00000020  0a 20 20 20 20 20 20 22  68 74 74 70 32 22 3a 20  |.      "http2": |
```