### PR TITLE
Fix/century pump light

### DIFF
--- a/scripts/pumps.js
+++ b/scripts/pumps.js
@@ -103,14 +103,11 @@
                     else {
                         // Determine pump on/off status based on pump type
                         var isOn = false;
-                        if (type.name === 'regalmodbus' || type.name === 'regalmodbus2') {
+                        if (type.name === 'regalmodbus') {
                             // For modbus pumps, use actual speed/flow indicators
                             // Pump is considered "on" if it's actually running at a speed > 0
                             isOn = (typeof data.rpm !== 'undefined' && data.rpm > 0) || 
                                    (typeof data.speed !== 'undefined' && data.speed > 0);
-                            if (data.id === 1) {  // Debug for pump 1 only to avoid spam
-                                console.debug(`[Pump ${data.id}] Modbus pump state - rpm: ${data.rpm}, speed: ${data.speed}, isOn: ${isOn}`);
-                            }
                         }
                         else {
                             // For relay-based pumps, use command or relay status

--- a/scripts/pumps.js
+++ b/scripts/pumps.js
@@ -100,8 +100,24 @@
                     el.css({ display: '' });
                     if (data.pumpOnDelay === true)
                         el.find('div.picIndicator').attr('data-status', 'delay');
-                    else
-                        el.find('div.picIndicator').attr('data-status', data.command === 10 || data.relay > 0 ? 'on' : 'off');
+                    else {
+                        // Determine pump on/off status based on pump type
+                        var isOn = false;
+                        if (type.name === 'regalmodbus' || type.name === 'regalmodbus2') {
+                            // For modbus pumps, use actual speed/flow indicators
+                            // Pump is considered "on" if it's actually running at a speed > 0
+                            isOn = (typeof data.rpm !== 'undefined' && data.rpm > 0) || 
+                                   (typeof data.speed !== 'undefined' && data.speed > 0);
+                            if (data.id === 1) {  // Debug for pump 1 only to avoid spam
+                                console.debug(`[Pump ${data.id}] Modbus pump state - rpm: ${data.rpm}, speed: ${data.speed}, isOn: ${isOn}`);
+                            }
+                        }
+                        else {
+                            // For relay-based pumps, use command or relay status
+                            isOn = data.command === 10 || data.relay > 0;
+                        }
+                        el.find('div.picIndicator').attr('data-status', isOn ? 'on' : 'off');
+                    }
                 }
                 el.attr('data-pumptype', data.type.val);
                 el.attr('data-id', data.id);


### PR DESCRIPTION
This pull request updates the logic for determining and displaying the on/off status of pumps in `scripts/pumps.js`. The main improvement is a more accurate status indication for different pump types, especially for Modbus-controlled pumps.

Pump status logic improvements:

* Enhanced the on/off status logic to distinguish between Modbus pumps (using `rpm` or `speed` values to determine if the pump is running) and relay-based pumps (using `command` or `relay` status). This ensures the UI accurately reflects the actual state of various pump types.
* Added a debug log for Modbus pump 1 to aid in troubleshooting and validation of the new logic.